### PR TITLE
Pull latest changes

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -33,7 +33,7 @@
 	# - If not set, check for STDIN availability:
 	#	OK | systemd	= no STDIN
 	#	OK | Cron	= no STDIN
-	#	NB | /etc/profile, ~/.profile, /etc/profile.d/, /etc/bash.bashrc, ~/.bashrc and /etc/bashrc.d/ can all be interactive since those are sourced from originating shell/bash session.
+	#	NB | /etc/profile, ~/.profile, /etc/profile.d/, /etc/bash.bashrc, ~/.bashrc and /etc/bashrc.d/ are interactive since those are sourced from originating shell/bash session.
 	if [[ $G_INTERACTIVE != [01] ]]; then
 
 		# Backwards compatibility to keep user scripts valid for a while
@@ -443,30 +443,24 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 	}
 
 	# $1 = mode
+	#	2	= Silent check, only returning error code if non-root
 	#	1	= Kill current script only, excluding the shell.
 	#	else	= Exit all linked scripts (kill all)
 	G_CHECK_ROOT_USER(){
 
-		if [[ $G_CHECK_ROOT_USER_VERIFIED != 1 ]]; then
+		if (( $UID )); then
 
-			if (( $UID )); then
+			[[ $1 == 2 ]] && return 1
 
-				G_DIETPI-NOTIFY 1 'Root privileges required. Please run the command with "sudo" or "G_SUDO".'
+			G_DIETPI-NOTIFY 1 'Root privileges required. Please run the command with "sudo" or "G_SUDO".'
 
-				if [[ $1 == 1 ]]; then
+			if [[ $1 == 1 ]]; then
 
-					kill -INT $$
-
-				else
-
-					exit 1
-
-				fi
+				kill -INT $$
 
 			else
 
-				export G_CHECK_ROOT_USER_VERIFIED=1
-				G_DIETPI-NOTIFY 0 'Root access verified'
+				exit 1
 
 			fi
 
@@ -487,7 +481,6 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 			else
 
 				export G_CHECK_ROOTFS_RW_VERIFIED=1
-				G_DIETPI-NOTIFY 0 'RootFS R/W access verified'
 
 			fi
 
@@ -864,16 +857,14 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 0
-			G_WHIP_RETURNED_VALUE=$(whiptail --title "$G_PROGRAM_NAME" --inputbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --default-item "$G_WHIP_DEFAULT_ITEM" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X "$G_WHIP_DEFAULT_ITEM" 3>&1 1>&2 2>&3; echo $? > /tmp/.G_WHIP_INPUTBOX_RESULT)
-			result=$(</tmp/.G_WHIP_INPUTBOX_RESULT)
+			G_WHIP_RETURNED_VALUE=$(whiptail --title "$G_PROGRAM_NAME" --inputbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --default-item "$G_WHIP_DEFAULT_ITEM" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X "$G_WHIP_DEFAULT_ITEM" 3>&1 1>&2 2>&3-; echo $? > /tmp/.G_WHIP_INPUTBOX_RESULT)
+			result=$(</tmp/.G_WHIP_INPUTBOX_RESULT); rm /tmp/.G_WHIP_INPUTBOX_RESULT
 			if (( $result == 0 )) && [[ -z $G_WHIP_RETURNED_VALUE ]]; then
 
 				result=1
 				whiptail --title "$G_PROGRAM_NAME" --msgbox '[FAILED] An input value was not entered.' --backtitle "$WHIP_BACKTITLE" 9 60
 
 			fi
-
-			rm /tmp/.G_WHIP_INPUTBOX_RESULT
 
 		fi
 
@@ -898,8 +889,8 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 			while :
 			do
 
-				local password_0=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
-				local password_1=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox 'Please enter the new password again:' --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+				local password_0=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3-)
+				local password_1=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox 'Please enter the new password again:' --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3-)
 				if [[ $password_0 && $password_0 == "$password_1" ]]; then
 
 					result=$password_0
@@ -933,10 +924,8 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 1
-			G_WHIP_RETURNED_VALUE=$(whiptail --title "$G_PROGRAM_NAME" --menu "$WHIP_MESSAGE" --default-item "$G_WHIP_DEFAULT_ITEM" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X $WHIP_SIZE_Z "${G_WHIP_MENU_ARRAY[@]}" 3>&1 1>&2 2>&3; echo $? > /tmp/.WHIP_MENU_RESULT)
-			result=$(</tmp/.WHIP_MENU_RESULT)
-
-			rm /tmp/.WHIP_MENU_RESULT
+			G_WHIP_RETURNED_VALUE=$(whiptail --title "$G_PROGRAM_NAME" --menu "$WHIP_MESSAGE" --default-item "$G_WHIP_DEFAULT_ITEM" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X $WHIP_SIZE_Z "${G_WHIP_MENU_ARRAY[@]}" 3>&1 1>&2 2>&3-; echo $? > /tmp/.WHIP_MENU_RESULT)
+			result=$(</tmp/.WHIP_MENU_RESULT); rm /tmp/.WHIP_MENU_RESULT
 
 		fi
 
@@ -957,11 +946,9 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 2
-			G_WHIP_RETURNED_VALUE=$(whiptail --title "$G_PROGRAM_NAME" --checklist "$WHIP_MESSAGE" --separate-output --default-item "$G_WHIP_DEFAULT_ITEM" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X $WHIP_SIZE_Z "${G_WHIP_CHECKLIST_ARRAY[@]}" 3>&1 1>&2 2>&3; echo $? > /tmp/.WHIP_CHECKLIST_RESULT)
+			G_WHIP_RETURNED_VALUE=$(whiptail --title "$G_PROGRAM_NAME" --checklist "$WHIP_MESSAGE" --separate-output --default-item "$G_WHIP_DEFAULT_ITEM" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X $WHIP_SIZE_Z "${G_WHIP_CHECKLIST_ARRAY[@]}" 3>&1 1>&2 2>&3-; echo $? > /tmp/.WHIP_CHECKLIST_RESULT)
 			G_WHIP_RETURNED_VALUE=$(echo -e "$G_WHIP_RETURNED_VALUE" | tr '\n' ' ')
-			result=$(</tmp/.WHIP_CHECKLIST_RESULT)
-
-			rm /tmp/.WHIP_CHECKLIST_RESULT
+			result=$(</tmp/.WHIP_CHECKLIST_RESULT); rm /tmp/.WHIP_CHECKLIST_RESULT
 
 		fi
 
@@ -1124,7 +1111,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 					local no_button_text='Exit'
 					[[ $G_ERROR_HANDLER_ONERROR_EXIT == 0 ]] && no_button_text='Ignore'
 
-					local choice=$(whiptail --title 'DietPi Error Handler:' --menu "$whip_msg" --cancel-button "$no_button_text" --scrolltext 24 90 $retry_menu_options_count "${aretry_menu_options[@]}" 3>&1 1>&2 2>&3)
+					local choice=$(whiptail --title 'DietPi Error Handler:' --menu "$whip_msg" --cancel-button "$no_button_text" --scrolltext 24 90 $retry_menu_options_count "${aretry_menu_options[@]}" 3>&1 1>&2 2>&3-)
 					if (( $? == 0 )); then
 
 						if [[ $choice == 'Retry' ]]; then


### PR DESCRIPTION
+ DietPi-Globals | Make G_CHECK_ROOT_USER() and G_CHECK_ROOTFS_RW() succeed silently. It is sufficient to print info in case of failure. G_CHECK_ROOT_USER() does not require an exported variable to prevent further checks then, since checking $UID is not slower then checking $G_CHECK_ROOT_USER_VERIFIED. By this, it is also assured that check is done if user is switched while preserving environment variables. For G_CHECK_ROOTFS_RW() we'll leave the variable in place, to prevent the relatively slow grep on /proc/mounts.
+ DietPi-Globals | After switching STDOUT with STDERR for G_WHIP returns, close temporary file descriptor &3
+ DietPi-Globals | Remove G_WHIP exit code file right after it was read to variable

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: WIP | Testing | Ready | ?
- [ ] Example task 1

**Reference**: https://github.com/MichaIng/DietPi/issues/XXXX

**Commit list/description**:
<!--
- DietPi-Config | Add "Fan control" option to "Performance Options"
![Screenshot](https://xxx.github.com/images/xxx.png)
- DietPi-Config | Add "Fan control" support for Odroid C2
- DietPi-Config | Syntax fix
-->
- ...
