### PR TITLE
v6.26

### DIFF
--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -178,14 +178,14 @@
 
 			G_WHIP_MSG 'Notice (locale):\n\nTo resolve broken locales, they have been reset to "en_GB.UTF-8".\n\nIf you had a different locale configured on this system, please use "dietpi-config" at a later date to re-configure.\n\nIn relation to that, DietPi does not use "/etc/environment" anymore, thus it is cleaned. In case you manually edited it, a backup was created: /mnt/dietpi_userdata/environment.bak'
 			#------------------------------------------------------------------------------
-			#Removed control from DietPi-Services: https://github.com/MichaIng/DietPi/issues/1501
+			# Removed control from DietPi-Services: https://github.com/MichaIng/DietPi/issues/1501
 			systemctl enable --now dnsmasq &> /dev/null
 			systemctl enable --now openvpn &> /dev/null
 			#-------------------------------------------------------------------------------
-			#https://dietpi.com/phpbb/viewtopic.php?f=11&t=2772&p=10646#p10646
+			# https://dietpi.com/phpbb/viewtopic.php?f=11&t=2772&p=10646#p10646
 			[[ -f '/etc/apt/sources.list.d/openmediavault.list' ]] && rm /etc/apt/sources.list.d/openmediavault.list
 			#-------------------------------------------------------------------------------
-			#DietPi-Software removals: https://github.com/MichaIng/DietPi/issues/1491
+			# DietPi-Software removals: https://github.com/MichaIng/DietPi/issues/1491
 			if [[ -f /DietPi/dietpi/.installed ]]; then
 
 				sed -i '/^aSOFTWARE_INSTALL_STATE\[100\]=/c\aSOFTWARE_INSTALL_STATE\[100\]=0' /DietPi/dietpi/.installed # Grashopper (now pijuice)
@@ -199,7 +199,7 @@
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Nodered lacks homedir, create it: https://github.com/MichaIng/DietPi/issues/1446#issuecomment-366370800
+			# Nodered lacks homedir, create it: https://github.com/MichaIng/DietPi/issues/1446#issuecomment-366370800
 			if getent passwd nodered &> /dev/null && [[ ! -d '/home/nodered' ]]; then
 
 				mkdir -p /home/nodered
@@ -207,17 +207,19 @@
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Reinstalls:
+			# Reinstalls:
 			# v6.20	NetData 1.9
 			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 2 )); then
 
 			#-------------------------------------------------------------------------------
-			#Switch from rc.local to own postboot script: https://github.com/MichaIng/DietPi/issues/1376
-			G_WHIP_MSG 'DietPi will not use "/etc/rc.local" for its own scripts anymore.\n\nHowever, in case you manually added something, we safe a backup to "/mnt/dietpi_userdata/rc.local.bak", from where you can copy & paste back to the cleaned "/etc/rc.local".\n\nIt will work as before.'
-			[[ -f '/etc/rc.local' ]] && mv /etc/rc.local /mnt/dietpi_userdata/rc.local.bak
-			cat << _EOF_ > /etc/rc.local
+			# Switch from rc.local to own postboot script: https://github.com/MichaIng/DietPi/issues/1376
+			if [[ -f '/etc/rc.local' ]]; then
+
+				G_WHIP_MSG 'DietPi will not use "/etc/rc.local" for its own scripts anymore.\n\nHowever, in case you manually added something, we safe a backup to "/mnt/dietpi_userdata/rc.local.bak", from where you can copy & paste back to the cleaned "/etc/rc.local".\n\nIt will work as before.'
+				mv /etc/rc.local /mnt/dietpi_userdata/rc.local.bak
+				cat << _EOF_ > /etc/rc.local
 #!/bin/sh -e
 #
 # rc.local
@@ -233,7 +235,9 @@
 
 exit 0
 _EOF_
-			chmod +x /etc/rc.local
+				chmod +x /etc/rc.local
+
+			fi
 
 			systemctl enable dietpi-postboot
 
@@ -242,7 +246,7 @@ _EOF_
 				[[ -d '/var/lib/dietpi/postboot.d' ]] || mkdir /var/lib/dietpi/postboot.d
 				cat << _EOF_ > /var/lib/dietpi/postboot.d/moode
 #!/bin/bash
-#moOde additions
+# moOde additions
 SQLDB=/var/local/www/db/moode-sqlite3.db
 
 # set cpu govenor
@@ -255,13 +259,13 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			G_DIETPI-NOTIFY 2 'Reducing getty count and resource usage:'
+			G_DIETPI-NOTIFY 2 'Reducing getty count and resource usage'
 			systemctl mask getty-static
 			#-------------------------------------------------------------------------------
-			# - Meveric, update repo to use our EU mirror: https://github.com/MichaIng/DietPi/issues/1519#issuecomment-368234302
+			# Meveric, update repo to use our EU mirror: https://github.com/MichaIng/DietPi/issues/1519#issuecomment-368234302
 			sed -i 's@https://oph.mdrjr.net/meveric@http://fuzon.co.uk/meveric@' /etc/apt/sources.list.d/meveric* &> /dev/null
 			#-------------------------------------------------------------------------------
-			#Remove any existing apt recommends settings, before applying ours: https://github.com/MichaIng/DietPi/issues/1482#issuecomment-368031044
+			# Remove any existing apt recommends settings, before applying ours: https://github.com/MichaIng/DietPi/issues/1482#issuecomment-368031044
 			rm -f /etc/apt/apt.conf.d/*recommends*
 
 			G_ERROR_HANDLER_COMMAND='/etc/apt/apt.conf.d/99-dietpi-norecommends'
@@ -274,7 +278,7 @@ _EOF_
 			G_ERROR_HANDLER_EXITCODE=$?
 			G_ERROR_HANDLER
 			#-------------------------------------------------------------------------------
-			#Reinstalls:
+			# Reinstalls:
 			# v6.5	Shairport-sync 3.1.7
 			# 	RPi Cam
 			#	Aria2 for .conf addition: https://github.com/MichaIng/DietPi/issues/1575#issuecomment-370248708
@@ -290,23 +294,21 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Add certificate combining for Lighttpd to CertBot auto renewal: https://github.com/MichaIng/DietPi/pull/1553
+			# Add certificate combining for Lighttpd to Certbot auto renewal: https://github.com/MichaIng/DietPi/pull/1553
 			if [[ -f '/DietPi/dietpi/.dietpi-letsencrypt' ]]; then
 
-				# - Switch Minio to new certbot.service.d/ hook:
+				# Switch Minio to new certbot.service.d/ hook:
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[158\]=2' /DietPi/dietpi/.installed; then
 
 					[[ -f '/etc/systemd/system/certbot.service' ]] && rm /etc/systemd/system/certbot.service
 
 				fi
-				# - Overall settings and config renewal:
-				/DietPi/dietpi/dietpi-letsencrypt 1
-				# - Stop services, started during dietpi-letsencrypt execution:
-				/DietPi/dietpi/dietpi-services stop
+				# Overall settings and config renewal, skip DietPi-Services:
+				G_DIETPI_SERVICES_DISABLE=1 /DietPi/dietpi/dietpi-letsencrypt 1
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Sparky SBC kernel patches: Pro-Ject-S2 dac DSD native support on sparky, also other few dac ids.
+			# Sparky SBC kernel patches: Pro-Ject-S2 dac DSD native support on sparky, also other few dac ids.
 			if (( $G_HW_MODEL == 70 )); then
 
 				G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/pro-ject-s2/snd-usb-audio.ko -O /lib/modules/$(uname -r)/kernel/sound/usb/snd-usb-audio.ko
@@ -314,7 +316,7 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			#GNU key management required for some APT installs via additional repos: https://github.com/MichaIng/DietPi/issues/1388
+			# GNU key management required for some APT installs via additional repos: https://github.com/MichaIng/DietPi/issues/1388
 			G_AGI dirmngr
 			#-------------------------------------------------------------------------------
 			# Odroids FFmpeg decendency fix: https://github.com/MichaIng/DietPi/issues/1556#issuecomment-369463910
@@ -2271,6 +2273,32 @@ Do you want to keep PulseAudio installed?' || apt-mark auto pulseaudio
 				fi
 				# Fail2Ban: Enable service since it is not controlled by DietPi-Services anymore: https://github.com/MichaIng/DietPi/commit/4d6ccbeee47b54247613f880a03339ff8a72f24d
 				grep -q '^aSOFTWARE_INSTALL_STATE\[73\]=2' /DietPi/dietpi/.installed && systemctl enable --now fail2ban
+				# Certbot: https://github.com/MichaIng/DietPi/issues/3111
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[92\]=2' /DietPi/dietpi/.installed; then
+
+					# Apache
+					if grep -q '^aSOFTWARE_INSTALL_STATE\[83\]=2' /DietPi/dietpi/.installed; then
+
+						G_AGI python3-certbot-apache
+						grep -q '^[[:blank:]]*authenticator[[:blank:]]*=[[:blank:]]*webroot' /etc/letsencrypt/renewal/*.conf 2> /dev/null &&
+						G_WHIP_YESNO '[Certbot] Switch back to native Apache authentication method\n
+Your Certbot authenticates with the "webroot" method, while you have an Apache webserver installed. This was required some time ago due to a sudden change by Let'\''s Encrypt, which made the Apache authentication method fail.
+Meanwhile, with current Certbot version, this bug has been fixed and we got some reports where the webroot method does not work reliable instead, leaving you with an expired HTTPS certificate in cases.\n
+Would you like to switch back to the Apache authentication method now?' && certbot renew --force-renewal -a apache
+
+					# Nginx
+					elif grep -q '^aSOFTWARE_INSTALL_STATE\[85\]=2' /DietPi/dietpi/.installed; then
+
+						G_AGI python3-certbot-nginx
+						grep -q '^[[:blank:]]*authenticator[[:blank:]]*=[[:blank:]]*webroot' /etc/letsencrypt/renewal/*.conf 2> /dev/null &&
+						G_WHIP_YESNO '[Certbot] Switch back to native Nginx authentication method\n
+Your Certbot authenticates with the "webroot" method, while you have an Nginx webserver installed. This was required some time ago due to a sudden change by Let'\''s Encrypt, which made the Nginx authentication method fail.
+Meanwhile, with current Certbot version, this bug has been fixed and we got some reports where the webroot method does not work reliable instead, leaving you with an expired HTTPS certificate in cases.\n
+Would you like to switch back to the Nginx authentication method now?' && certbot renew --force-renewal -a nginx
+
+					fi
+
+				fi
 				# Webmin: https://github.com/MichaIng/DietPi/commit/ec55d49a488fd9cb1dbb18cbfa067b5d1d1a974e
 				/DietPi/dietpi/dietpi-software reinstall 115
 


### PR DESCRIPTION
+ DietPi-Patch | Certbot: Offer users to migrate from webroot authentication back to Apache/Nginx plugin

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: WIP | Testing | Ready | ?
- [ ] Example task 1

**Reference**: https://github.com/MichaIng/DietPi/issues/XXXX

**Commit list/description**:
<!--
- DietPi-Config | Add "Fan control" option to "Performance Options"
![Screenshot](https://xxx.github.com/images/xxx.png)
- DietPi-Config | Add "Fan control" support for Odroid C2
- DietPi-Config | Syntax fix
-->
- ...
